### PR TITLE
refactor: stop using deprecated stencil apis

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ionic/pwa-elements",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/components/camera-modal/camera-modal-instance.tsx
+++ b/src/components/camera-modal/camera-modal-instance.tsx
@@ -1,12 +1,13 @@
-import { h, Event, EventEmitter, Component, Listen, Element } from '@stencil/core';
+import { h, Event, EventEmitter, Component, Listen, Host } from '@stencil/core';
 
 @Component({
   tag: 'pwa-camera-modal-instance',
   styleUrl: 'camera-modal-instance.css',
   shadow: true
 })
-export class PWACameraModal {
-  @Element() el;
+export class PWACameraModalInstance {
+  el: HTMLPwaCameraModalInstanceElement;
+
   @Event() onPhoto: EventEmitter;
 
   async handlePhoto(photo: any) {
@@ -30,8 +31,8 @@ export class PWACameraModal {
     }
   }
 
-  render() {
-    return (
+  render = () => (
+    <Host ref={(el: HTMLPwaCameraModalInstanceElement) => (this.el = el)}>
       <div class="wrapper" onClick={e => this.handleBackdropClick(e)}>
         <div class="content">
           <pwa-camera
@@ -39,6 +40,6 @@ export class PWACameraModal {
             onPhoto={(photo) => this.handlePhoto(photo)} />
         </div>
       </div>
-    );
-  }
+    </Host>
+  );
 }

--- a/src/components/camera-modal/camera-modal-instance.tsx
+++ b/src/components/camera-modal/camera-modal-instance.tsx
@@ -1,4 +1,4 @@
-import { h, Event, EventEmitter, Component, Listen, Host } from '@stencil/core';
+import { h, Event, EventEmitter, Component, Listen, Element } from '@stencil/core';
 
 @Component({
   tag: 'pwa-camera-modal-instance',
@@ -6,7 +6,7 @@ import { h, Event, EventEmitter, Component, Listen, Host } from '@stencil/core';
   shadow: true
 })
 export class PWACameraModalInstance {
-  el: HTMLPwaCameraModalInstanceElement;
+  @Element() el: HTMLPwaCameraModalInstanceElement;
 
   @Event() onPhoto: EventEmitter;
 
@@ -31,8 +31,8 @@ export class PWACameraModalInstance {
     }
   }
 
-  render = () => (
-    <Host ref={(el: HTMLPwaCameraModalInstanceElement) => (this.el = el)}>
+  render() {
+    return (
       <div class="wrapper" onClick={e => this.handleBackdropClick(e)}>
         <div class="content">
           <pwa-camera
@@ -40,6 +40,6 @@ export class PWACameraModalInstance {
             onPhoto={(photo) => this.handlePhoto(photo)} />
         </div>
       </div>
-    </Host>
-  );
+    );
+  }
 }

--- a/src/components/camera-modal/camera-modal.tsx
+++ b/src/components/camera-modal/camera-modal.tsx
@@ -8,7 +8,7 @@ import { h, Event, EventEmitter, Component, Method } from '@stencil/core';
 export class PWACameraModal {
   @Event() onPhoto: EventEmitter;
 
-  _modal: HTMLElement;
+  _modal: HTMLPwaCameraModalInstanceElement;
 
   @Method()
   async present() {

--- a/src/components/camera/camera.tsx
+++ b/src/components/camera/camera.tsx
@@ -1,4 +1,4 @@
-import { h, Component, Element, Prop, State } from '@stencil/core';
+import { h, Component, Host, Prop, State, Build, getAssetPath } from '@stencil/core';
 
 import { FlashMode } from '../../definitions';
 
@@ -6,17 +6,16 @@ import './imagecapture';
 
 declare var window: any;
 
+const assetPath = getAssetPath('.');
+
 @Component({
   tag: 'pwa-camera',
   styleUrl: 'camera.css',
-  assetsDir: 'icons',
+  assetsDirs: ['icons'],
   shadow: true
 })
-export class CameraPWA {
-  @Element() el;
-
-  @Prop({ context: 'isServer' }) private isServer: boolean;
-  @Prop({ context: 'publicPath'}) private publicPath: string;
+export class PWACamera {
+  el: HTMLPwaCameraElement;
 
   @Prop() facingMode: string = 'user';
 
@@ -50,7 +49,7 @@ export class CameraPWA {
   flashMode: FlashMode = 'off';
 
   async componentDidLoad() {
-    if (this.isServer) {
+    if (!Build.isBrowser) {
       return;
     }
 
@@ -156,7 +155,7 @@ export class CameraPWA {
         const photo = await this.imageCapture.takePhoto({
           fillLightMode: this.flashModes.length > 1 ? this.flashMode : undefined
         });
-        
+
         await this.flashScreen();
 
         this.promptAccept(photo);
@@ -250,20 +249,20 @@ export class CameraPWA {
     this.onPhoto && this.onPhoto(this.photo);
   }
 
-  render() {
-    return (
+  render = () => (
+    <Host ref={(el: HTMLPwaCameraElement) => (this.el = el)}>
       <div class="camera-wrapper">
         <div class="camera-header">
           <section class="items">
             <div class="item close" onClick={e => this.handleClose(e)}>
-              <img src={`${this.publicPath}icons/exit.svg`} />
+              <img src={`${assetPath}icons/exit.svg`} />
             </div>
             <div class="item flash" onClick={e => this.handleFlashClick(e)}>
               {this.flashModes.length > 0 && (
               <div>
-                {this.flashMode == 'off' ? <img src={`${this.publicPath}icons/flash-off.svg`} /> : ''}
-                {this.flashMode == 'auto' ? <img src={`${this.publicPath}icons/flash-auto.svg`} /> : ''}
-                {this.flashMode == 'flash' ? <img src={`${this.publicPath}icons/flash-on.svg`} /> : ''}
+                {this.flashMode == 'off' ? <img src={`${assetPath}icons/flash-off.svg`} /> : ''}
+                {this.flashMode == 'auto' ? <img src={`${assetPath}icons/flash-auto.svg`} /> : ''}
+                {this.flashMode == 'flash' ? <img src={`${assetPath}icons/flash-on.svg`} /> : ''}
               </div>
               )}
             </div>
@@ -302,21 +301,21 @@ export class CameraPWA {
             <div class="shutter-button"></div>
           </div>,
           <div class="rotate" onClick={(e) => this.handleRotateClick(e)}>
-            <img src={`${this.publicPath}icons/reverse-camera.svg`} />
+            <img src={`${assetPath}icons/reverse-camera.svg`} />
           </div>,
           {/*this.hasMultipleCameras && (<div class="item rotate" onClick={(e) => this.handleRotateClick(e)}></div>)*/}
           ]) : (
           <section class="items">
             <div class="item accept-cancel" onClick={e => this.handleCancelPhoto(e)}>
-              <img src={`${this.publicPath}icons/retake.svg`} />
+              <img src={`${assetPath}icons/retake.svg`} />
             </div>
             <div class="item accept-use" onClick={e => this.handleAcceptPhoto(e)}>
-              <img src={`${this.publicPath}icons/confirm.svg`} />
+              <img src={`${assetPath}icons/confirm.svg`} />
             </div>
           </section>
           )}
         </div>
       </div>
-    );
-  }
+    </Host>
+  );
 }

--- a/src/components/camera/camera.tsx
+++ b/src/components/camera/camera.tsx
@@ -10,7 +10,7 @@ declare var window: any;
   tag: 'pwa-camera',
   styleUrl: 'camera.css',
   assetsDirs: ['icons'],
-  shadow: true,
+  shadow: true
 })
 export class PWACamera {
   @Element() el: HTMLPwaCameraElement;
@@ -52,8 +52,8 @@ export class PWACamera {
 
     this.defaultConstraints = {
       video: {
-        facingMode: this.facingMode,
-      },
+        facingMode: this.facingMode
+      }
     };
 
     // Figure out how many cameras we have
@@ -79,7 +79,7 @@ export class PWACamera {
     try {
       const devices = await navigator.mediaDevices.enumerateDevices();
       this.hasMultipleCameras = devices.filter(d => d.kind == 'videoinput').length > 1;
-    } catch (e) {
+    } catch(e) {
       this.onPhoto(e);
     }
   }
@@ -144,7 +144,7 @@ export class PWACamera {
     if (this.hasImageCapture()) {
       try {
         const photo = await this.imageCapture.takePhoto({
-          fillLightMode: this.flashModes.length > 1 ? this.flashMode : undefined,
+          fillLightMode: this.flashModes.length > 1 ? this.flashMode : undefined
         });
 
         await this.flashScreen();
@@ -180,14 +180,14 @@ export class PWACamera {
     if (facingMode === 'environment') {
       this.initCamera({
         video: {
-          facingMode: 'user',
-        },
+          facingMode: 'user'
+        }
       });
     } else {
       this.initCamera({
         video: {
-          facingMode: 'environment',
-        },
+          facingMode: 'environment'
+        }
       });
     }
   }
@@ -215,7 +215,6 @@ export class PWACamera {
   }
 
   handleShutterClick(_e: Event) {
-    console.log();
     this.capture();
   }
 
@@ -292,40 +291,33 @@ export class PWACamera {
         {/* Show the taken photo for the Accept UI*/}
         {this.photo && (
           <div class="accept">
-            <div class="accept-image" style={{ backgroundImage: `url(${this.photoSrc})` }} />
+            <div class="accept-image" style={{backgroundImage: `url(${this.photoSrc})`}}></div>
           </div>
         )}
 
         {/* Only toggle visibility of the video feed to keep it responsive */}
         <div class="camera-video" style={{ display: this.photo ? 'none' : '' }}>
-          {this.showShutterOverlay && <div class="shutter-overlay" />}
-          {this.hasImageCapture() ? (
-            <video
-              style={videoStreamStyle}
-              ref={(el: HTMLVideoElement) => (this.videoElement = el)}
-              autoplay
-              playsinline
-            />
-          ) : (
-            <canvas ref={(el: HTMLCanvasElement) => (this.canvasElement = el)} width="100%" height="100%" />
+          {this.showShutterOverlay && (
+            <div class="shutter-overlay"></div>
           )}
-          <canvas class="offscreen-image-render" ref={e => (this.offscreenCanvas = e)} width="100%" height="100%" />
+          {this.hasImageCapture() ? (
+            <video style={videoStreamStyle} ref={el => (this.videoElement = el)} autoplay playsinline />
+          ) : (
+            <canvas ref={el => this.canvasElement = el} width="100%" height="100%"></canvas>
+          )}
+          <canvas class="offscreen-image-render" ref={el => this.offscreenCanvas = el} width="100%" height="100%" />
         </div>
 
         <div class="camera-footer">
-          {!this.photo ? (
-            [
-              <div class="shutter" onClick={e => this.handleShutterClick(e)}>
-                <div class="shutter-button" />
-              </div>,
-              <div class="rotate" onClick={e => this.handleRotateClick(e)}>
-                <img src={this.iconReverseCamera()} />
-              </div>,
-              {
-                /*this.hasMultipleCameras && (<div class="item rotate" onClick={(e) => this.handleRotateClick(e)}></div>)*/
-              },
-            ]
-          ) : (
+          {!this.photo ? ([
+            <div class="shutter" onClick={(e) => this.handleShutterClick(e)}>
+              <div class="shutter-button"></div>
+            </div>,
+            <div class="rotate" onClick={(e) => this.handleRotateClick(e)}>
+              <img src={this.iconReverseCamera()} />
+            </div>,
+            {/*this.hasMultipleCameras && (<div class="item rotate" onClick={(e) => this.handleRotateClick(e)}></div>)*/}
+            ]) : (
             <section class="items">
               <div class="item accept-cancel" onClick={e => this.handleCancelPhoto(e)}>
                 <img src={this.iconRetake()} />

--- a/src/components/camera/camera.tsx
+++ b/src/components/camera/camera.tsx
@@ -1,4 +1,4 @@
-import { h, Component, Host, Prop, State, Build, getAssetPath } from '@stencil/core';
+import { h, Component, Element, Prop, State, Build, getAssetPath } from '@stencil/core';
 
 import { FlashMode } from '../../definitions';
 
@@ -15,7 +15,7 @@ const assetPath = getAssetPath('.');
   shadow: true
 })
 export class PWACamera {
-  el: HTMLPwaCameraElement;
+  @Element() el: HTMLPwaCameraElement;
 
   @Prop() facingMode: string = 'user';
 
@@ -249,8 +249,8 @@ export class PWACamera {
     this.onPhoto && this.onPhoto(this.photo);
   }
 
-  render = () => (
-    <Host ref={(el: HTMLPwaCameraElement) => (this.el = el)}>
+  render () {
+    return (
       <div class="camera-wrapper">
         <div class="camera-header">
           <section class="items">
@@ -316,6 +316,6 @@ export class PWACamera {
           )}
         </div>
       </div>
-    </Host>
-  );
+    );
+  }
 }

--- a/src/components/camera/camera.tsx
+++ b/src/components/camera/camera.tsx
@@ -249,7 +249,7 @@ export class PWACamera {
     this.onPhoto && this.onPhoto(this.photo);
   }
 
-  render () {
+  render() {
     return (
       <div class="camera-wrapper">
         <div class="camera-header">

--- a/src/components/camera/camera.tsx
+++ b/src/components/camera/camera.tsx
@@ -93,11 +93,11 @@ export class PWACamera {
       const stream = await navigator.mediaDevices.getUserMedia({
         video: true,
         audio: false,
-        ...constraints,
+        ...constraints
       });
 
       this.initStream(stream);
-    } catch (e) {
+    } catch(e) {
       this.onPhoto(e);
     }
   }
@@ -267,7 +267,7 @@ export class PWACamera {
   }
 
   render() {
-    const videoStreamStyle = this.facingMode == 'user' ? { transform: 'scaleX(-1)' } : {};
+    const videoStreamStyle = this.facingMode == "user" ? { transform: 'scaleX(-1)' } : {};
 
     return (
       <div class="camera-wrapper">
@@ -301,7 +301,7 @@ export class PWACamera {
             <div class="shutter-overlay"></div>
           )}
           {this.hasImageCapture() ? (
-            <video style={videoStreamStyle} ref={el => (this.videoElement = el)} autoplay playsinline />
+            <video style={videoStreamStyle} ref={el => (this.videoElement = el)} autoplay playsinline></video>
           ) : (
             <canvas ref={el => this.canvasElement = el} width="100%" height="100%"></canvas>
           )}

--- a/src/components/toast/toast.tsx
+++ b/src/components/toast/toast.tsx
@@ -1,4 +1,4 @@
-import { h, Component, Prop, Host, State } from '@stencil/core';
+import { h, Component, Prop, Element, Host, State } from '@stencil/core';
 
 @Component({
   tag: 'pwa-toast',
@@ -6,7 +6,7 @@ import { h, Component, Prop, Host, State } from '@stencil/core';
   shadow: true
 })
 export class PWAToast {
-  el: HTMLPwaToastElement;
+  @Element() el: HTMLPwaToastElement;
 
   @Prop() message: string;
 
@@ -31,10 +31,7 @@ export class PWAToast {
   }
 
   render = () => (
-    <Host ref={(el: HTMLPwaToastElement) => (this.el = el)} class={{
-      in: this.closing !== null && !this.closing,
-      out: !!this.closing,
-    }}>
+    <Host class={{ in: this.closing !== null && !this.closing, out: !!this.closing }}>
       <div class="wrapper">
         <div class="toast">
           {this.message}

--- a/src/components/toast/toast.tsx
+++ b/src/components/toast/toast.tsx
@@ -1,4 +1,4 @@
-import { h, Component, Prop, Element, State } from '@stencil/core';
+import { h, Component, Prop, Host, State } from '@stencil/core';
 
 @Component({
   tag: 'pwa-toast',
@@ -6,26 +6,13 @@ import { h, Component, Prop, Element, State } from '@stencil/core';
   shadow: true
 })
 export class PWAToast {
-  @Element() el: HTMLElement;
+  el: HTMLPwaToastElement;
 
   @Prop() message: string;
 
   @Prop() duration: number = 2000;
 
   @State() closing = null;
-
-  hostData() {
-    const classes = {
-      out: !!this.closing
-    }
-
-    if (this.closing !== null) {
-      classes['in'] = !this.closing;
-    }
-    return {
-      class: classes
-    }
-  }
 
   componentDidLoad() {
     setTimeout(() => {
@@ -43,13 +30,16 @@ export class PWAToast {
     }, 1000);
   }
 
-  render() {
-    return (
+  render = () => (
+    <Host ref={(el: HTMLPwaToastElement) => (this.el = el)} class={{
+      in: this.closing !== null && !this.closing,
+      out: !!this.closing,
+    }}>
       <div class="wrapper">
         <div class="toast">
           {this.message}
         </div>
       </div>
-    );
-  }
+    </Host>
+  );
 }

--- a/src/components/toast/toast.tsx
+++ b/src/components/toast/toast.tsx
@@ -30,13 +30,15 @@ export class PWAToast {
     }, 1000);
   }
 
-  render = () => (
-    <Host class={{ in: this.closing !== null && !this.closing, out: !!this.closing }}>
-      <div class="wrapper">
-        <div class="toast">
-          {this.message}
+  render() {
+    return (
+      <Host class={{ in: this.closing !== null && !this.closing, out: !!this.closing }}>
+        <div class="wrapper">
+          <div class="toast">
+            {this.message}
+          </div>
         </div>
-      </div>
-    </Host>
-  );
+      </Host>
+    );
+  }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0">
-  <title>Stencil Component Starter</title>
+  <title>PWA Elements</title>
   <style>
     html, body {
       width: 100%;


### PR DESCRIPTION
- context `isServer` => `!Build.isBrowser`
- context `publicPath` => `getAssetPath('.')`
- `assetsDir` => `assetsDirs`
- `hostData()` => `<Host class={{ ... }}>`