### PR TITLE
Return error if something fails

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -34,7 +34,7 @@
         const photo = e.detail;
         console.log('CAMERA ON PHOTO', photo);
 
-        if (photo) {
+        if (photo && !photo instanceof Error) {
           const url = window.URL.createObjectURL(photo);
 
           const img = document.querySelector('#img') || document.createElement('img');
@@ -44,6 +44,8 @@
           img.parentNode && img.parentNode.removeChild(img);
 
           document.body.appendChild(img);
+        } else if (photo) {
+          console.error(photo.message);
         }
 
         // Hide the modal


### PR DESCRIPTION
Right now, if something fails (no camera detected, getUserMedia not available, not in a secure context, etc.), the camera shows the modal with an error message or just a black screen and people don't know why and have created a few Capacitor issues already.

This change removes the black screen and instead returns the error so users can't act (Capacitor Camera will also need to be updated to reject the getPicture promise when an error is returned)

Might be better to have an onError event, but as currently it’s returning a null photo when the user cancels, I also sent the the onPhoto 

Closes #14
