### PR TITLE
FIX Error "Duplicate identifier 'ElementTagNameMap'" with Typescript 3.5.2

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -92,7 +92,5 @@ declare global {
     'pwa-camera-modal-instance': HTMLPwaCameraModalInstanceElement;
     'pwa-toast': HTMLPwaToastElement;
   }
-
-  interface ElementTagNameMap extends HTMLElementTagNameMap {}
 }
 


### PR DESCRIPTION
When you are building a Typescript project in Vue it shows the following message: "Duplicate identifier 'ElementTagNameMap'"
This fixes that issue.

Attachment screenshot
![ISSUE](https://user-images.githubusercontent.com/27731047/60743872-c64ee900-9f49-11e9-861c-f785d99e176f.png)

