### PR TITLE
fix: remove video z-index to prevent bug on firefox / brave

### DIFF
--- a/src/components/camera/camera.css
+++ b/src/components/camera/camera.css
@@ -76,7 +76,7 @@ video {
   height: 100%;
   max-height: 100%;
   min-height: 100%;
-  z-index: -1;
+  z-index: 1;
   object-fit: cover;
   background-color: black;
 }

--- a/src/components/camera/camera.css
+++ b/src/components/camera/camera.css
@@ -76,7 +76,6 @@ video {
   height: 100%;
   max-height: 100%;
   min-height: 100%;
-  z-index: 1;
   object-fit: cover;
   background-color: black;
 }


### PR DESCRIPTION
On firefox there is problem with video z-index when taking photo. It doesn't appear after permission gain and It's black until photo is taken.