### PR TITLE
fix: camera rotate not working on safari

### DIFF
--- a/src/components/camera/camera.tsx
+++ b/src/components/camera/camera.tsx
@@ -255,6 +255,7 @@ export class CameraPWA {
     let facingMode = c.facingMode;
 
     if (!facingMode) {
+    if (!facingMode && facingMode !== undefined) {
       let c = track.getCapabilities();
       facingMode = c.facingMode[0];
     }


### PR DESCRIPTION
As described in #74, there are issues rotating the camera in a Safari browser. Adding a small change to the code solves this problem.