### PR TITLE
fix: stopStream causes the browser to freeze on some Android 11 devices

### DIFF
--- a/src/components/camera/camera.tsx
+++ b/src/components/camera/camera.tsx
@@ -151,6 +151,7 @@ export class CameraPWA {
   }
 
   stopStream() {
+    this.videoElement.srcObject = null;
     this.stream && this.stream.getTracks().forEach(track => track.stop());
   }
 

--- a/src/components/camera/camera.tsx
+++ b/src/components/camera/camera.tsx
@@ -151,7 +151,9 @@ export class CameraPWA {
   }
 
   stopStream() {
-    this.videoElement.srcObject = null;
+    if (this.videoElement) {
+      this.videoElement.srcObject = null;
+    }
     this.stream && this.stream.getTracks().forEach(track => track.stop());
   }
 


### PR DESCRIPTION
Fixes the issue causing some Android 11 devices to freeze Chrome while switching between rear and front cameras.