### PR TITLE
fix(camera): undefined background image url when taking picture

### DIFF
--- a/src/components/camera/camera.tsx
+++ b/src/components/camera/camera.tsx
@@ -428,7 +428,7 @@ export class CameraPWA {
           </div>
         )}
         {/* Show the taken photo for the Accept UI*/}
-        {this.photo ? (
+        {this.photoSrc ? (
         <div class="accept">
           <div
             class="accept-image"


### PR DESCRIPTION
One of two possible fixes for https://github.com/ionic-team/pwa-elements/issues/85

The other pull request: https://github.com/ionic-team/pwa-elements/pull/86