### PR TITLE
chore: replace stencil slack with discord channel

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Please see our [Contributor Code of Conduct](https://github.com/ionic-team/stenc
 
 ## Creating an Issue
 
-* If you have a question about using Stencil, please ask in the [Stencil Worldwide Slack](https://join.slack.com/t/stencil-worldwide/shared_invite/enQtMjQ2MzkyMTY0MTk0LTQ4ODgzYjFjNjdkNDY3YWVhMmNlMTljMWQxNTM3Yjg0ZTIyZTM1MmU2YWE5YzNjNzE1MmQ3ZTk2NjQ1YzM5ZDM group.
+* If you have a question about using Stencil, please ask in the [Stencil discord channel](https://chat.stenciljs.com).
 
 * It is required that you clearly describe the steps necessary to reproduce the issue you are running into. Although we would love to help our users as much as possible, diagnosing issues without clear reproduction steps is extremely time-consuming and simply not sustainable.
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -10,7 +10,7 @@ Before submitting an issue, please consult our [docs](https://stenciljs.com/).
 **I'm submitting a ...**  (check one with "x")
 [ ] bug report
 [ ] feature request
-[ ] support request => Please do not submit support requests here, use one of these channels: https://forum.ionicframework.com/ or https://stencil-worldwide.slack.com
+[ ] support request => Please do not submit support requests here, use one of these channels: https://forum.ionicframework.com/ or https://chat.stenciljs.com
 
 **Current behavior:**
 <!-- Describe how the bug manifests. -->


### PR DESCRIPTION
Updates references for the Stencil slack channel to reference the Discord.