### PR TITLE
fix: enable es5 build output

### DIFF
--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -9,6 +9,7 @@ export const config: Config = {
     },
     { type: 'www' },
   ],
+  buildEs5: true,
   extras: {
     enableImportInjection: true
   }


### PR DESCRIPTION
In previous versions of this package, it was distributed with an es5 output: https://unpkg.com/@ionic/pwa-elements@3.1.0/dist/ionicpwaelements/ionicpwaelements.js.

In v3.2.0 when upgrading Stencil, this default behavior changed and building for es5 became opt-in. By not enabling this flag in the config, this regressed environments consuming that output: https://unpkg.com/@ionic/pwa-elements@latest/dist/ionicpwaelements/ionicpwaelements.js (results in a 404).

This PR re-enables building es5 output. 