### PR TITLE
fix: disable source maps

### DIFF
--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -9,7 +9,8 @@ export const config: Config = {
     },
     { type: 'www' },
   ],
-  buildEs5: true,
+  buildEs5: "prod",
+  sourceMap: false,
   extras: {
     enableImportInjection: true
   }


### PR DESCRIPTION
Resolves: #124

After investigation into #124, it was observed that the es5 build output changed during Stencil v3 when sourcemaps were enabled by default. This is causing issues with certain webpack environments. Since we did not intend to enable sourcemap generation to resolve another issue, I recommend we disable sourcemap generation to maintain compatibility with existing projects until we remove the es5 output in a future major release. 