### PR TITLE
feat(camera): allow for additional accept types for image selection

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -14,6 +14,11 @@ export namespace Components {
         "options": ActionSheetOption[];
     }
     interface PwaCamera {
+        /**
+          * The acceptable image input for selection when a camera is not available.  Defaults to: `image/*`.
+          * @see https://html.spec.whatwg.org/multipage/input.html#attr-input-accept
+         */
+        "accept": string;
         "facingMode": string;
         "handleNoDeviceError": (e?: any) => void;
         "handlePhoto": (photo: Blob) => void;
@@ -94,6 +99,11 @@ declare namespace LocalJSX {
         "options"?: ActionSheetOption[];
     }
     interface PwaCamera {
+        /**
+          * The acceptable image input for selection when a camera is not available.  Defaults to: `image/*`.
+          * @see https://html.spec.whatwg.org/multipage/input.html#attr-input-accept
+         */
+        "accept"?: string;
         "facingMode"?: string;
         "handleNoDeviceError"?: (e?: any) => void;
         "handlePhoto"?: (photo: Blob) => void;

--- a/src/components/camera/camera.tsx
+++ b/src/components/camera/camera.tsx
@@ -21,6 +21,13 @@ export class CameraPWA {
   @Prop() handleNoDeviceError: (e?: any) => void;
   @Prop() noDevicesText = 'No camera found';
   @Prop() noDevicesButtonText = 'Choose image';
+  /**
+   * The acceptable image input for selection when a camera is not available.
+   * Defaults to: `image/*`.
+   *
+   * @see https://html.spec.whatwg.org/multipage/input.html#attr-input-accept
+   */
+  @Prop() accept = 'image/*';
 
   @State() photo: any;
   @State() photoSrc: any;
@@ -427,7 +434,7 @@ export class CameraPWA {
               type="file"
               id="_pwa-elements-camera-input"
               onChange={this.handleFileInputChange}
-              accept="image/*"
+              accept={this.accept}
               class="select-file-button" />
           </div>
         )}


### PR DESCRIPTION
Resolves #80

Adds an additional property to the `pwa-camera` to allow developers to specify additional acceptable file types when a camera device is not available. This feature is intended to be used to restrict the file types to more specific patterns than the default `image/*` matches to. For example, restricting to only `png` or `jpeg` image file types.