### PR TITLE
chore: run release without tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "stencil build",
     "start": "stencil build --dev --watch --serve",
-    "release": "np",
+    "release": "np --no-tests",
     "version": "npm run build"
   },
   "repository": {


### PR DESCRIPTION
np will try to run tests before the release, but the package has no tests, so it fails.
Adding `--no-tests` to the release script to skip tests.