### PR TITLE
fix(camera): resolve black screen issue in Telegram WebView by adding 'muted' attribute

### DIFF
--- a/src/components/camera/camera.tsx
+++ b/src/components/camera/camera.tsx
@@ -453,7 +453,8 @@ export class CameraPWA {
               ref={(el: HTMLVideoElement) => this.videoElement = el}
               onLoadedMetaData={this.handleVideoMetadata}
               autoplay
-              playsinline />
+              playsinline
+              muted />
             ) : (
             <canvas ref={(el: HTMLCanvasElement) => this.canvasElement = el} width="100%" height="100%"></canvas>
             )}


### PR DESCRIPTION
**Description:**

This pull request addresses the issue where the video feed appears as a black screen when accessing the camera stream inside Telegram WebView. The problem was caused by WebView autoplay policies that prevent videos from playing unless they are muted.

**Changes Made:**
- Added the `muted` attribute to the `<video>` element to ensure that the camera stream plays correctly in Telegram WebView.

**Related Issue:**
- This PR fixes the issue described in Issue #135

**Steps to Test:**
1. Open the app inside Telegram WebView.
2. Access the camera stream.
3. Verify that the video feed is displayed correctly and not as a black screen.

**Additional Information:**
- The `muted` attribute is required due to WebView's autoplay restrictions, which affect video playback.
- This fix ensures compatibility with Telegram WebView and improves the overall user experience.